### PR TITLE
RVN-189

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -340,9 +340,9 @@ impl CameraBuffer<'_> {
     }
 
     pub fn fd(&self) -> BorrowedFd<'_> {
-        // the raw_fd allocated by v4l2 will stay valid until the CameraReader is
-        // closed. The camerabuffer lifetime is at most the same as the CameraReader, so
-        // this borrow is safe
+        // SAFETY: the raw_fd allocated by v4l2 will stay valid until the CameraReader
+        // is closed. The camerabuffer lifetime is at most the same as the
+        // CameraReader, so this borrow is safe
         unsafe { BorrowedFd::borrow_raw(self.raw_fd) }
     }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use std::{
     error::Error,
     ffi::{c_int, CString},
     fmt, io,
-    os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd},
+    os::fd::{BorrowedFd, FromRawFd, RawFd},
 };
 use unix_ts::Timestamp;
 use videostream_sys as ffi;
@@ -395,7 +395,7 @@ impl fmt::Display for CameraBuffer<'_> {
             self.width(),
             self.height(),
             self.format(),
-            self.fd,
+            self.rawfd(),
             self.ptr
         )
     }


### PR DESCRIPTION
camerabuffer.rawfd() now gives access to the rawfd provided by the camera driver, instead of a duplicated one.